### PR TITLE
Fix for matchClasses Regular Expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ type RenameOptions = {
    * The default is to match the name with word boundaries on either side, but you can change this to match only the start or end of the name, or to match more or less than a whole word.
    *
    * @default ```js
-   * (key: string) => `(:^|[^-&;:_])(${key})(:$|[^-&;:_\./])`
+   * (key: string) => `(:^|[^-&;:_])(${key})(?![a-zA-Z0-9_-])(:$|[^-&;:_\./])`
    * ```
    */
   matchClasses?: (key: string) => string;

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,5 +6,5 @@ export const defaultOptions = {
     by: 'whole',
   },
   targetExt: ['html', 'js'],
-  matchClasses: (key: string) => `(:^|[^-&;:_])(${key})(:$|[^-&;:_\./])`,
+  matchClasses: (key: string) => `(:^|[^-&;:_])(${key})(?![a-zA-Z0-9_-])(:$|[^-&;:_\./])`,
 } satisfies RenameOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export type RenameOptions =
        * The default is to match the name with word boundaries on either side, but you can change this to match only the start or end of the name, or to match more or less than a whole word.
        *
        * @default ```js
-       * (key: string) => `(:^|[^-&;:_])(${key})(:$|[^-&;:_\./])`
+       * (key: string) => `(:^|[^-&;:_])(${key})(?![a-zA-Z0-9_-])(:$|[^-&;:_\./])`
        * ```
        */
       matchClasses?: (key: string) => string;


### PR DESCRIPTION
Thanks for this awesome Astro integration!

When running this Astro integration on a project that uses TailwindCSS classes, I noticed that if I had two CSS classes in the project, for example, `h-2` and `h-20`, then the `matchClasses` regular expression with the `key` set to `h-2` would match for instances of `h-20` (a valid CSS class). This would prevent `h-20` from being renamed properly. 

The update I made to the regular expression simply adds a negative lookahead assertion that ensures that the match is not followed by any alphanumeric, underscore or hyphen characters (valid characters in a CSS class).

Ideally, if the `key` is set to `h-2`, then it should only rename `h-2`, not `h-20`, `h-2a`, `h-2_`, etc.