### PR TITLE
Feat: Small improvements

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,6 @@
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/consistent-type-imports": "error",
-    "no-console": "error",
     "no-useless-concat": "error",
     "prefer-template": "error",
     "arrow-body-style": "error",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "sideEffects": [],
-  "engines": {
-    "node": ">=20.2"
-  }
+  "sideEffects": []
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "sideEffects": []
+  "sideEffects": [],
+  "engines": {
+    "node": ">=18.18"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ export default function renameIntegration(
         try {
           await mkdir(dir);
         } catch (_) {
-          // eslint-disable-next-line no-console
           console.error(
             `\u001b[31mTemporal directory to process files couldn't be created.\u001b[39m`
           );
@@ -46,7 +45,6 @@ export default function renameIntegration(
             flag: 'w',
           });
         } catch (_) {
-          // eslint-disable-next-line no-console
           console.error(
             `\u001b[31mThere was an error saving the CSS map.\u001b[39m`
           );
@@ -98,7 +96,6 @@ export default function renameIntegration(
             };
           }
         } catch (_) {
-          // eslint-disable-next-line no-console
           console.error(
             `\u001b[31mA CSS map of transformed classes it isn't provided\u001b[39m`
           );
@@ -147,7 +144,6 @@ export default function renameIntegration(
 
           stats.printTable();
         } catch (_) {
-          // eslint-disable-next-line no-console
           console.error(
             `\u001b[31mThe build directory doesn't exists.\u001b[39m`
           );
@@ -157,7 +153,6 @@ export default function renameIntegration(
         try {
           await rmdir(MAPS_DIRECTORY, { recursive: true });
         } catch (_) {
-          // eslint-disable-next-line no-console
           console.error(
             `\u001b[31mIt was not possible to remove the class maps directory.\u001b[39m`
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, rmdir, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { brotliCompressSync, gzipSync } from 'node:zlib';
@@ -28,10 +29,11 @@ export default function renameIntegration(
       ...options?.rename,
       outputMapCallback: async (map) => {
         const content = JSON.stringify(map);
-        const dir = MAPS_DIRECTORY;
 
         try {
-          await mkdir(dir);
+          if (!existsSync(MAPS_DIRECTORY)) {
+            await mkdir(MAPS_DIRECTORY);
+          }
         } catch (err) {
           console.error(
             `\u001b[31mTemporal directory to process files couldn't be created: ${err}.\u001b[39m`
@@ -40,10 +42,14 @@ export default function renameIntegration(
         }
 
         try {
-          await writeFile(`${dir}/class-map-${md5(content)}.json`, content, {
-            encoding: 'utf8',
-            flag: 'w',
-          });
+          await writeFile(
+            `${MAPS_DIRECTORY}/class-map-${md5(content)}.json`,
+            content,
+            {
+              encoding: 'utf8',
+              flag: 'w',
+            }
+          );
         } catch (err) {
           console.error(
             `\u001b[31mThere was an error saving the CSS map: ${err}.\u001b[39m`

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,9 +96,10 @@ export default function renameIntegration(
 
         try {
           for await (const map of walkFiles(MAPS_DIRECTORY)) {
+            const res = await readFile(map, 'utf8');
             classMap = {
               ...classMap,
-              ...JSON.parse(await readFile(map, 'utf8')),
+              ...JSON.parse(res),
             };
           }
         } catch (_) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,9 @@ export default function renameIntegration(
 
         try {
           await mkdir(dir);
-        } catch (_) {
+        } catch (err) {
           console.error(
-            `\u001b[31mTemporal directory to process files couldn't be created.\u001b[39m`
+            `\u001b[31mTemporal directory to process files couldn't be created: ${err}.\u001b[39m`
           );
           return;
         }
@@ -44,9 +44,9 @@ export default function renameIntegration(
             encoding: 'utf8',
             flag: 'w',
           });
-        } catch (_) {
+        } catch (err) {
           console.error(
-            `\u001b[31mThere was an error saving the CSS map.\u001b[39m`
+            `\u001b[31mThere was an error saving the CSS map: ${err}.\u001b[39m`
           );
           return;
         }
@@ -152,9 +152,9 @@ export default function renameIntegration(
 
         try {
           await rmdir(MAPS_DIRECTORY, { recursive: true });
-        } catch (_) {
+        } catch (err) {
           console.error(
-            `\u001b[31mIt was not possible to remove the class maps directory.\u001b[39m`
+            `\u001b[31mIt was not possible to remove the class maps directory: ${err}\u001b[39m`
           );
         }
       },


### PR DESCRIPTION
Hi @RodrigoTomeES, this PR will fix and introduce a few things:

### Features

- Log error messages from some try/catch blocks. (This will help to debug any future errors)
- Verify if `MAPS_DIRECTORY` already exists before `mkdir`:

![Screenshot from 2023-10-17 12-51-23](https://github.com/RodrigoTomeES/astro-rename/assets/76869974/449c404d-8d7c-4e82-a63d-0aba721eb82f)

### Changes

- Remove `no-console` rule to avoid using `eslint-disable-next-line no-console`
- Reduce node version requirement from `20.2` to `18.18`

### Fixes

- Wait for `readFile` method before JSON parsing.

For some reason, the `classMap` always return a single item after the `for await`:

https://github.com/RodrigoTomeES/astro-rename/blob/44ce009567ef82067a86e4099a517a0cdeccb926/src/index.ts#L94-L99

After this PR, we first wait for the `readFile` method and then parse with `JSON.parse`:

```js
for await (const map of walkFiles(MAPS_DIRECTORY)) {
  const res = await readFile(map, 'utf8');
  classMap = {
    ...classMap,
    ...JSON.parse(res),
  };
}
```

### Issues

- Closes - #5 